### PR TITLE
Fix Bundle verify method

### DIFF
--- a/src/BundleInterface.ts
+++ b/src/BundleInterface.ts
@@ -6,10 +6,10 @@ import { JWKInterface } from './interface-jwk';
 type ResolvesTo<T> = T | Promise<T> | ((...args: any[]) => Promise<T>);
 
 export interface BundleInterface {
-  readonly length: ResolvesTo<number>
+  readonly length: ResolvesTo<number>;
   readonly items: BundleItem[] | AsyncGenerator<BundleItem>;
   get(index: number | string): BundleItem | Promise<BundleItem>;
   getIds(): string[] | Promise<string[]>;
-  getRaw(): ResolvesTo<Buffer>
+  getRaw(): ResolvesTo<Buffer>;
   toTransaction(arweave: Arweave, jwk: JWKInterface): Promise<Transaction>;
 }


### PR DESCRIPTION
The current implementation of the Bundle verify method is broken, as it calls an asynchronous verify function on each of the Bundle DataItems, and can result in crashes outside of the process.

This PR makes the Bundle.verify method asynchronous as it should be.

I removed the optional `verify` param of the constructor for now otherwise you would have to await on new instances.

Possibly related to #1 